### PR TITLE
Resolves #20

### DIFF
--- a/src/js/directives/controls/ng_model_control.js
+++ b/src/js/directives/controls/ng_model_control.js
@@ -13,6 +13,12 @@
             link: function(scope, iElement, iAttrs, controller) {
                 var ngModelCtrl = controller[0],
                     chipsCtrl = controller[1];
+
+                scope.onSelect = function (item,model,label,event) {
+                    if(ngModelCtrl.$modelValue === item)
+                        ngModelCtrl.$render()
+                }
+                
                 ngModelCtrl.$render = function(event) {
                     if (!ngModelCtrl.$modelValue)
                         return;


### PR DESCRIPTION
https://github.com/mohbasheer/angular-chips/issues/20

Details: 

I noticed a bug when using this plugin with the typeahead plugin from bootstrap, it's present in the demo as well.

If you type the exact name of one of the selections, it will not let you add it to the chips, however if you type less than the full exact name, or don't use capital letters where the item in question uses them, it will let you select it.

For example, on the demo typing FaceBook will not let you hit enter and select the choice, but Facebook or typing Face and hitting enter will.