### PR TITLE
Fix 'main' parameter in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "run-sequence": "^1.1.5",
     "st": "^1.1.0"
   },
-  "main": "gulpfile.js",
+  "main": "dist/angular-chips.min.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Needs to require the module properly
```js
require('angular-chips');
```